### PR TITLE
#4: Rename of deprecated pep8 to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ script:
 
   # Run codestyle checks
   - cd "$TRAVIS_BUILD_DIR"
-  - pip install pep8
-  - pep8 --config=setup.cfg --statistics -v .
+  - pip install pycodestyle
+  - pycodestyle --config=setup.cfg --statistics -v .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120


### PR DESCRIPTION
This is a fix of issue #4 