### PR TITLE
Backslashes escaping in datetime regular expression

### DIFF
--- a/pytextutils/datetimes.py
+++ b/pytextutils/datetimes.py
@@ -56,8 +56,8 @@ def parse_russian_date(text_value, now_dt):
     text_value = str(text_value)
 
     month_names_group = '|'.join(month_name_to_numbers.keys())
-    dates_reg = '^\s*(?P<day>\d+)\s+(?P<month_name>' + month_names_group \
-        + ')\s+((?P<year>20\d{2})(\s+года)?)?(\s*в)?\s+(?P<hours>\d|[012]\d):(?P<minutes>\d{2})'
+    dates_reg = '^\\s*(?P<day>\\d+)\\s+(?P<month_name>' + month_names_group \
+        + ')\\s+((?P<year>20\\d{2})(\\s+года)?)?(\\s*в)?\\s+(?P<hours>\\d|[012]\\d):(?P<minutes>\\d{2})'
 
     match = re.search(dates_reg, text_value, re.IGNORECASE | re.UNICODE)
     if not match:


### PR DESCRIPTION
The build is failed due to non-escaped singular backslashes:
```
...
checking ./pytextutils/datetimes.py
./pytextutils/datetimes.py:59:19: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:59:30: W605 invalid escape sequence '\d'
./pytextutils/datetimes.py:59:34: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:60:13: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:60:28: W605 invalid escape sequence '\d'
./pytextutils/datetimes.py:60:35: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:60:47: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:60:53: W605 invalid escape sequence '\s'
./pytextutils/datetimes.py:60:66: W605 invalid escape sequence '\d'
./pytextutils/datetimes.py:60:74: W605 invalid escape sequence '\d'
./pytextutils/datetimes.py:60:90: W605 invalid escape sequence '\d'
checking ./pytextutils/numbers.py
directory ./tests
checking ./tests/tests_datetimes.py
checking ./tests/tests_numbers.py
11      W605 invalid escape sequence '\s'
The command "pycodestyle --config=setup.cfg --statistics -v ." exited with 1.
```

This pull request should fix this problem.